### PR TITLE
Adiciona método getPdfBoletoBase64

### DIFF
--- a/src/BancoInter.php
+++ b/src/BancoInter.php
@@ -261,7 +261,31 @@ class BancoInter
         
         return $filename;
     }
-    
+
+    /**
+     * Faz download do PDF do boleto e retorna apenas o conteúdo binário
+     * codificado em string base64
+     *
+     * @param  string $nossoNumero
+     * @throws BancoInterException
+     * @return string Conteúdo do PDF codificado em string base64
+     */
+    public function getPdfBoletoBase64(string $nossoNumero) : string
+    {
+        $http_params = ['accept: application/pdf'];
+
+        $reply = $this->controllerGet(
+            "/openbanking/v1/certificado/boletos/$nossoNumero/pdf",
+            $http_params
+        );
+
+        if (!$reply->body) {
+            throw new BancoInterException("Erro ao receber o PDF", 0, $reply);
+        }
+
+        return $reply->body;
+    }
+
     public function baixaBoleto(string $nossoNumero, string $motivo = "ACERTOS")
     {
         $data = new StdSerializable();


### PR DESCRIPTION
Olá @allgood 

Estou utilizando sua lib e precisei de um método que retornasse apenas o binário do PDF codificado em string base64 para adicioná-lo como anexo no envio de e-mail.

Eu poderia ter utilizado o `getPdfBoleto`, mas para não ter que repetir o processo de ler o arquivo temporário do disco e converter novamente para base64 criei esse outro método.

Essa é minha contribuição com a proposta de adicioná-lo.

Muito obrigado. 👍

