### PR TITLE
Added return type mixed to jsonSerialize function

### DIFF
--- a/src/Cobranca/Boleto.php
+++ b/src/Cobranca/Boleto.php
@@ -352,7 +352,7 @@ class Boleto implements \JsonSerializable
         $this->mora = new Mora();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Cobranca/Desconto.php
+++ b/src/Cobranca/Desconto.php
@@ -81,7 +81,7 @@ class Desconto implements \JsonSerializable
         $this->data = $data;
     }
     
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Cobranca/Mensagem.php
+++ b/src/Cobranca/Mensagem.php
@@ -89,7 +89,7 @@ class Mensagem implements \JsonSerializable
         $this->linha5 = $linha5;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Cobranca/Mora.php
+++ b/src/Cobranca/Mora.php
@@ -77,7 +77,7 @@ class Mora implements \JsonSerializable
         $this->data = $data;
     }
     
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Cobranca/Multa.php
+++ b/src/Cobranca/Multa.php
@@ -76,7 +76,7 @@ class Multa implements \JsonSerializable
         $this->data = $data;
     }
     
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Cobranca/Pagador.php
+++ b/src/Cobranca/Pagador.php
@@ -260,7 +260,7 @@ class Pagador implements \JsonSerializable
         $this->telefone = $telefone;
     }
     
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/StdSerializable.php
+++ b/src/StdSerializable.php
@@ -9,7 +9,7 @@ namespace ctodobom\APInterPHP;
  */
 class StdSerializable extends \stdClass implements \JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }


### PR DESCRIPTION
Just added the return type mixed to the jsonSerialize function to stop deprecation warnings in php 8.1