### PR TITLE
Adicionada função getSaldo(DateTime)

### DIFF
--- a/src/BancoInter.php
+++ b/src/BancoInter.php
@@ -517,12 +517,12 @@ class BancoInter
      * @param \DateTime $dataSaldo
      * @return float
      */
-    public function getSaldo(\DateTime $dataSaldo = new \DateTime()): ?float {
+    public function getSaldo(\DateTime $dataSaldo = new \DateTime()): ?float
+    {
 
         $reply = $this->controllerGet("/banking/v2/saldo?dataSaldo=" . $dataSaldo->format('Y-m-d'));
         $replyData = json_decode($reply->body);
 
         return $replyData->disponivel ?? null;
-
     }
 }

--- a/src/BancoInter.php
+++ b/src/BancoInter.php
@@ -525,4 +525,25 @@ class BancoInter
 
         return $replyData->disponivel ?? null;
     }
+
+    /**
+     * Consulta o extrato em um período entre datas específico. Para utilizar esta chamada,
+     * suas credenciais junto ao Banco Inter precisam ter acesso à permissão "Consulta de extrato
+     * e saldo", e você precisa declarar o escopo extrato.read ao criar o TokenRequest.
+     *
+     * @param \DateTime dataInicio
+     * @param \DateTime dataFim
+     * @return \stdClass
+     */
+    public function getExtrato(\DateTime $dataInicio, \DateTime $dataFim): \stdClass
+    {
+        $params['dataInicio'] = $dataInicio->format('Y-m-d');
+        $params['dataFim'] = $dataFim->format('Y-m-d');
+
+        $url = "/banking/v2/extrato?" . http_build_query($params);
+
+        $reply = $this->controllerGet($url);
+
+        return json_decode($reply->body);
+    }
 }

--- a/src/BancoInter.php
+++ b/src/BancoInter.php
@@ -508,4 +508,21 @@ class BancoInter
     {
         $this->tokenLoadCallback = $callback;
     }
+
+
+    /**
+     * Retorna o saldo da conta na data informada. Caso não seja informada
+     * uma data, retorna o saldo atual.
+     *
+     * @param \DateTime $dataSaldo
+     * @return float
+     */
+    public function getSaldo(\DateTime $dataSaldo = new \DateTime()): ?float {
+
+        $reply = $this->controllerGet("/banking/v2/saldo?dataSaldo=" . $dataSaldo->format('Y-m-d'));
+        $replyData = json_decode($reply->body);
+
+        return $replyData->disponivel ?? null;
+
+    }
 }


### PR DESCRIPTION
Criada uma função que utiliza o endpoint **Consultar saldo**, conforme orientações da documentação:

GET https://cdpj.partners.bancointer.com.br/banking/v2/saldo

_Documentação Inter:_
Método utilizado para consultar o saldo por um período específico.
Este endpoint está implementado com um rate-limit de 10 chamadas por minuto.
O token para realizar esta chamada precisa conter o escopo: **extrato.read**

A função retorna o saldo como float, ou null caso não encontre o parâmetro "disponível" no JSON retornado. (em tese, nunca é para acontecer).

O json retorna um float, e não um string. PHP_FLOAT_MAX em 64 bits fica perto da casa dos bilhões/trilhões, então considero seguro o PHP retornar em float, sem risco de overflow.