### PR TITLE
Função getSaldo compatibilidade PHP 7.4

### DIFF
--- a/src/BancoInter.php
+++ b/src/BancoInter.php
@@ -519,7 +519,9 @@ class BancoInter
      */
     public function getSaldo(\DateTime $dataSaldo = null): ?float
     {
-        if (!$dataSaldo) $dataSaldo = new \DateTime();
+        if (!$dataSaldo) {
+            $dataSaldo = new \DateTime();
+        }
 
         $reply = $this->controllerGet("/banking/v2/saldo?dataSaldo=" . $dataSaldo->format('Y-m-d'));
         $replyData = json_decode($reply->body);

--- a/src/BancoInter.php
+++ b/src/BancoInter.php
@@ -517,8 +517,9 @@ class BancoInter
      * @param \DateTime $dataSaldo
      * @return float
      */
-    public function getSaldo(\DateTime $dataSaldo = new \DateTime()): ?float
+    public function getSaldo(\DateTime $dataSaldo = null): ?float
     {
+        if (!$dataSaldo) $dataSaldo = new \DateTime();
 
         $reply = $this->controllerGet("/banking/v2/saldo?dataSaldo=" . $dataSaldo->format('Y-m-d'));
         $replyData = json_decode($reply->body);


### PR DESCRIPTION
Os testes do phpunit não passaram para o PHP 7.4. O parâmetro opcional dataSaldo, na função getSaldo, quando não informado deve ser uma constante e não dinamicamente atribuído como eu tinha feito (new \DateTime). Falha minha.

Fiz a correção para o php 7.4 e rodei o phpunit para fazer os testes. Rodei também no container docker e tudo funcionou.
